### PR TITLE
making the metadata image bigger

### DIFF
--- a/packages/dapp/src/components/pages/About.tsx
+++ b/packages/dapp/src/components/pages/About.tsx
@@ -131,7 +131,7 @@ export const AboutPage = () => {
             my={10}
             display={{ base: 'flex', md: 'none' }}
             src={extractsColorsAndMetadataImg}
-            maxH="200pt"
+            maxH="600pt"
             align="center"
           />
         </Flex>
@@ -176,7 +176,7 @@ export const AboutPage = () => {
             <Image
               display={{ base: 'none', md: 'flex' }}
               src={extractsColorsAndMetadataImg}
-              maxH="250pt"
+              maxH="600pt"
             />
           </Flex>
         </HStack>


### PR DESCRIPTION
Tweaking maxH for the extractsColorsAndMetadataImg so that it appears readable. At its current size, it's too small to read.