### PR TITLE
Let's delete the Garden algorithm!

### DIFF
--- a/packages/dapp/src/components/pages/About.tsx
+++ b/packages/dapp/src/components/pages/About.tsx
@@ -67,17 +67,11 @@ export const AboutPage = () => {
                 </Slide>
                 <Slide index={1}>
                   <SlImage
-                    src="/samples/bayc_15.png"
-                    hasMasterSpinner={false}
-                  />{' '}
-                </Slide>
-                <Slide index={2}>
-                  <SlImage
                     src="/samples/beginning_sample.png"
                     hasMasterSpinner={false}
                   />
                 </Slide>
-                <Slide index={3}>
+                <Slide index={2}>
                   <SlImage
                     src="/samples/frog_6729.png"
                     hasMasterSpinner={false}


### PR DESCRIPTION
I'd once again (firmly!) suggest we get rid of the Garden algorithm sample on our landing page because:
1. Visually it's pretty weak
2. I'll be messing with the algorithm so it will most likely look quite different how that bored ape sample looks
3. It's confusing to show something on the site that's not available
3. Given what I saw and heard about at the conference, drops and reveals are exciting, so let's show our strongest samples (the other three) and wait to drop/reveal the garden one