### PR TITLE
Edit "Asset" to read "NFT"

### DIFF
--- a/packages/dapp/src/components/pages/MyAssets.tsx
+++ b/packages/dapp/src/components/pages/MyAssets.tsx
@@ -102,7 +102,7 @@ export const MyAssetsPage = () => {
       {chainId && (
         <>
           {nfts.length > 0 && (
-            <Heading size="md">choose an asset to splice:</Heading>
+            <Heading size="md">choose an NFT to splice:</Heading>
           )}
           <SimpleGrid
             columns={[1, 2, 3, 4]}


### PR DESCRIPTION
Because "NFT" is clearer and more human: we're only using NFTs as a seed (no other type of asset) and "NFT" is the term that collectors usually use.