### PR TITLE
Edit "Assets" to read "NFTs"

### DIFF
--- a/packages/dapp/src/components/pages/NFTPage.tsx
+++ b/packages/dapp/src/components/pages/NFTPage.tsx
@@ -151,7 +151,7 @@ export const NFTPage = () => {
       <Breadcrumb>
         <BreadcrumbItem>
           <BreadcrumbLink as={NavLink} to="/my-assets">
-            Your Assets
+            Your NFTs
           </BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbItem isCurrentPage>


### PR DESCRIPTION
Because it's clearer, friendlier, and the terminology collectors use