### PR TITLE
Streamlining design of breadcrumb text

### DIFF
--- a/packages/dapp/src/components/pages/NFTPage.tsx
+++ b/packages/dapp/src/components/pages/NFTPage.tsx
@@ -151,12 +151,13 @@ export const NFTPage = () => {
       <Breadcrumb>
         <BreadcrumbItem>
           <BreadcrumbLink as={NavLink} to="/my-assets">
-            Your NFTs
+             <Heading size="md">Your NFTs</Heading>
           </BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbItem isCurrentPage>
           <BreadcrumbLink>
-            {heritage ? '' : 'Mint'} Splice for {nftMetadata?.name}
+            <Heading size="md">{heritage ? '' : 'Mint'} Splice for {nftMetadata?.name}</Heading>
+            
           </BreadcrumbLink>
         </BreadcrumbItem>
       </Breadcrumb>


### PR DESCRIPTION
Setting the breadcrumb text to the same heading size as the text that appears in the same position on the page before